### PR TITLE
Fix javadoc wording in Screen

### DIFF
--- a/src/main/java/info/qbnet/jtvision/core/Screen.java
+++ b/src/main/java/info/qbnet/jtvision/core/Screen.java
@@ -105,7 +105,7 @@ public class Screen {
     }
 
     /**
-     * Sets a character at a specific position with the default color
+     * Sets a character at a specific position with the default colors.
      * @param x horizontal coordinate
      * @param y vertical coordinate
      * @param c character to display


### PR DESCRIPTION
## Summary
- clarify javadoc about default colors in `Screen.setChar` method

## Testing
- `mvn test` *(fails: PluginResolutionException due to network)*

------
https://chatgpt.com/codex/tasks/task_e_6881658798a883219b4baba76c6516cd