### PR TITLE
Implement dynamic screen resizing

### DIFF
--- a/src/main/java/info/qbnet/jtvision/backend/JavaFxBitmapBackend.java
+++ b/src/main/java/info/qbnet/jtvision/backend/JavaFxBitmapBackend.java
@@ -91,4 +91,14 @@ public class JavaFxBitmapBackend implements JavaFxFactory.FxBackendWithCanvas {
     public Canvas getCanvas() {
         return canvas;
     }
+
+    @Override
+    public int getCharWidth() {
+        return CHAR_WIDTH;
+    }
+
+    @Override
+    public int getCharHeight() {
+        return CHAR_HEIGHT;
+    }
 }

--- a/src/main/java/info/qbnet/jtvision/backend/JavaFxTrueTypeBackend.java
+++ b/src/main/java/info/qbnet/jtvision/backend/JavaFxTrueTypeBackend.java
@@ -72,4 +72,14 @@ public class JavaFxTrueTypeBackend implements JavaFxFactory.FxBackendWithCanvas 
     public Canvas getCanvas() {
         return canvas;
     }
+
+    @Override
+    public int getCharWidth() {
+        return CHAR_WIDTH;
+    }
+
+    @Override
+    public int getCharHeight() {
+        return CHAR_HEIGHT;
+    }
 }

--- a/src/main/java/info/qbnet/jtvision/backend/LibGdxBitmapBackend.java
+++ b/src/main/java/info/qbnet/jtvision/backend/LibGdxBitmapBackend.java
@@ -84,6 +84,9 @@ public class LibGdxBitmapBackend extends ApplicationAdapter implements Backend {
     @Override
     public void resize(int width, int height) {
         viewport.update(width, height);
+        int cols = Math.max(Screen.MIN_WIDTH, width / CHAR_WIDTH);
+        int rows = Math.max(Screen.MIN_HEIGHT, height / CHAR_HEIGHT);
+        screen.resize(cols, rows);
     }
 
     private Color convert(java.awt.Color awtColor) {

--- a/src/main/java/info/qbnet/jtvision/backend/LibGdxTrueTypeBackend.java
+++ b/src/main/java/info/qbnet/jtvision/backend/LibGdxTrueTypeBackend.java
@@ -86,6 +86,9 @@ public class LibGdxTrueTypeBackend extends ApplicationAdapter implements Backend
     @Override
     public void resize(int width, int height) {
         viewport.update(width, height);
+        int cols = Math.max(Screen.MIN_WIDTH, width / CHAR_WIDTH);
+        int rows = Math.max(Screen.MIN_HEIGHT, height / CHAR_HEIGHT);
+        screen.resize(cols, rows);
     }
 
     private Color convert(java.awt.Color awtColor) {

--- a/src/main/java/info/qbnet/jtvision/backend/SwingBasicBackend.java
+++ b/src/main/java/info/qbnet/jtvision/backend/SwingBasicBackend.java
@@ -24,6 +24,15 @@ public class SwingBasicBackend extends JPanel implements SwingFactory.SwingBacke
         Dimension size = new Dimension(buffer.getWidth() * CHAR_WIDTH,
                 buffer.getHeight() * CHAR_HEIGHT);
         setPreferredSize(size);
+        addComponentListener(new java.awt.event.ComponentAdapter() {
+            @Override
+            public void componentResized(java.awt.event.ComponentEvent e) {
+                int cols = Math.max(Screen.MIN_WIDTH, getWidth() / CHAR_WIDTH);
+                int rows = Math.max(Screen.MIN_HEIGHT, getHeight() / CHAR_HEIGHT);
+                buffer.resize(cols, rows);
+                repaint();
+            }
+        });
         setFont(new Font(Font.MONOSPACED, Font.PLAIN, 14));
     }
 

--- a/src/main/java/info/qbnet/jtvision/backend/SwingBitmapBackend.java
+++ b/src/main/java/info/qbnet/jtvision/backend/SwingBitmapBackend.java
@@ -19,7 +19,7 @@ public class SwingBitmapBackend extends JPanel implements SwingFactory.SwingBack
     private static final int CHAR_HEIGHT = 16;
     private final Screen buffer;
     private final BufferedImage fontAtlas;
-    private final BufferedImage backBuffer;
+    private BufferedImage backBuffer;
 
     public SwingBitmapBackend(Screen buffer) {
         this.buffer = buffer;
@@ -40,6 +40,16 @@ public class SwingBitmapBackend extends JPanel implements SwingFactory.SwingBack
         this.backBuffer = new BufferedImage(width, height, BufferedImage.TYPE_INT_ARGB);
 
         setPreferredSize(new Dimension(width, height));
+        addComponentListener(new java.awt.event.ComponentAdapter() {
+            @Override
+            public void componentResized(java.awt.event.ComponentEvent e) {
+                int cols = Math.max(Screen.MIN_WIDTH, getWidth() / CHAR_WIDTH);
+                int rows = Math.max(Screen.MIN_HEIGHT, getHeight() / CHAR_HEIGHT);
+                buffer.resize(cols, rows);
+                updateBackBuffer();
+                repaint();
+            }
+        });
     }
 
     @Override
@@ -59,6 +69,14 @@ public class SwingBitmapBackend extends JPanel implements SwingFactory.SwingBack
             }
         }
         g2d.dispose();
+    }
+
+    private void updateBackBuffer() {
+        int width = buffer.getWidth() * CHAR_WIDTH;
+        int height = buffer.getHeight() * CHAR_HEIGHT;
+        backBuffer = new BufferedImage(width, height, BufferedImage.TYPE_INT_ARGB);
+        setPreferredSize(new Dimension(width, height));
+        revalidate();
     }
 
     @Override

--- a/src/main/java/info/qbnet/jtvision/backend/SwingTrueTypeBackend.java
+++ b/src/main/java/info/qbnet/jtvision/backend/SwingTrueTypeBackend.java
@@ -20,7 +20,7 @@ public class SwingTrueTypeBackend extends JPanel implements SwingFactory.SwingBa
     private static final int CHAR_HEIGHT = 16;
     private final Screen buffer;
     private final Font font;
-    private final BufferedImage backBuffer;
+    private BufferedImage backBuffer;
 
     public SwingTrueTypeBackend(Screen buffer) {
         this.buffer = buffer;
@@ -39,6 +39,16 @@ public class SwingTrueTypeBackend extends JPanel implements SwingFactory.SwingBa
         this.backBuffer = new BufferedImage(width, height, BufferedImage.TYPE_INT_ARGB);
 
         setPreferredSize(new Dimension(width, height));
+        addComponentListener(new java.awt.event.ComponentAdapter() {
+            @Override
+            public void componentResized(java.awt.event.ComponentEvent e) {
+                int cols = Math.max(Screen.MIN_WIDTH, getWidth() / CHAR_WIDTH);
+                int rows = Math.max(Screen.MIN_HEIGHT, getHeight() / CHAR_HEIGHT);
+                buffer.resize(cols, rows);
+                updateBackBuffer();
+                repaint();
+            }
+        });
     }
 
     @Override
@@ -85,6 +95,14 @@ public class SwingTrueTypeBackend extends JPanel implements SwingFactory.SwingBa
         FontRenderContext frc = new FontRenderContext(null, false, false);
         GlyphVector gv = font.createGlyphVector(frc, new char[] { sc.getCharacter() });
         g.drawGlyphVector(gv, px, py + CHAR_HEIGHT - 3);
+    }
+
+    private void updateBackBuffer() {
+        int width = buffer.getWidth() * CHAR_WIDTH;
+        int height = buffer.getHeight() * CHAR_HEIGHT;
+        backBuffer = new BufferedImage(width, height, BufferedImage.TYPE_INT_ARGB);
+        setPreferredSize(new Dimension(width, height));
+        revalidate();
     }
 
     @Override

--- a/src/main/java/info/qbnet/jtvision/backend/factory/JavaFxFactory.java
+++ b/src/main/java/info/qbnet/jtvision/backend/factory/JavaFxFactory.java
@@ -44,6 +44,22 @@ public class JavaFxFactory implements Factory {
             stage.setScene(scene);
             stage.show();
 
+            backendWithCanvas.getCanvas().widthProperty().bind(root.widthProperty());
+            backendWithCanvas.getCanvas().heightProperty().bind(root.heightProperty());
+
+            root.widthProperty().addListener((obs, oldVal, newVal) -> {
+                int cols = Math.max(Screen.MIN_WIDTH,
+                        (int) (newVal.doubleValue() / backendWithCanvas.getCharWidth()));
+                buffer.resize(cols, buffer.getHeight());
+                backend.render();
+            });
+            root.heightProperty().addListener((obs, oldVal, newVal) -> {
+                int rows = Math.max(Screen.MIN_HEIGHT,
+                        (int) (newVal.doubleValue() / backendWithCanvas.getCharHeight()));
+                buffer.resize(buffer.getWidth(), rows);
+                backend.render();
+            });
+
             latch.countDown();
         });
 
@@ -58,5 +74,7 @@ public class JavaFxFactory implements Factory {
 
     public interface FxBackendWithCanvas extends Backend {
         Canvas getCanvas();
+        int getCharWidth();
+        int getCharHeight();
     }
 }


### PR DESCRIPTION
## Summary
- allow `Screen` to resize and retain contents
- propagate resize events from Swing, JavaFX and LibGDX backends
- adjust factories and backends for dynamic canvas/panel sizes
- enforce minimum console size of 80x25

## Testing
- `mvn -q -DskipTests package` *(fails: Plugin resolution from Maven Central)*


------
https://chatgpt.com/codex/tasks/task_e_68816ed22234832180267b72c6c69c2f