### PR TITLE
Use consistent centering spelling in TView option comments

### DIFF
--- a/src/main/java/info/qbnet/jtvision/core/views/TView.java
+++ b/src/main/java/info/qbnet/jtvision/core/views/TView.java
@@ -148,11 +148,11 @@ public class TView {
         public static final int OF_BUFFERED     = 1 << 6;
         /** Bit flag allowing the view to tile its owner. */
         public static final int OF_TILEABLE     = 1 << 7;
-        /** Bit flag centring the view horizontally. */
+        /** Bit flag centering the view horizontally. */
         public static final int OF_CENTER_X     = 1 << 8;
-        /** Bit flag centring the view vertically. */
+        /** Bit flag centering the view vertically. */
         public static final int OF_CENTER_Y     = 1 << 9;
-        /** Combined bit flag for centring in both axes (OF_CENTER_X | OF_CENTER_Y). */
+        /** Combined bit flag for centering in both axes (OF_CENTER_X | OF_CENTER_Y). */
         public static final int OF_CENTER       = OF_CENTER_X | OF_CENTER_Y;
         /** Bit flag enabling validation before changes. */
         public static final int OF_VALIDATE     = 1 << 10;


### PR DESCRIPTION
## Summary
- Use "centering" spelling for OF_CENTER_X, OF_CENTER_Y, and OF_CENTER comments

## Testing
- `mvn test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 or one of its dependencies could not be resolved: Cannot access central in offline mode)*

------
https://chatgpt.com/codex/tasks/task_e_68a479174d708321afb790484ebd3efb